### PR TITLE
Replace translation specific "now" and "today" date expressions with …

### DIFF
--- a/app/controllers/library/DashboardController.php
+++ b/app/controllers/library/DashboardController.php
@@ -57,7 +57,7 @@
  		 */
  		public function Index() {
  			AssetLoadManager::register("jquery", "scrollto");
- 			if (!($ps_daterange = $this->request->getParameter('daterange', pString))) { $ps_daterange = _t('today'); }
+ 			if (!($ps_daterange = $this->request->getParameter('daterange', pString))) { $ps_daterange = TimeExpressionParser::todayExpression(); }
  			
 			$va_dashboard_config = $this->opo_library_services_config->getAssoc('dashboard');
  			

--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -996,7 +996,7 @@ jQuery(document).ready(function() {
 					}
 				}
 
-				if ($t_item->hasField('is_deaccessioned') && $t_item->get('is_deaccessioned') && ($t_item->get('deaccession_date', array('getDirectDate' => true)) <= caDateToHistoricTimestamp(_t('now')))) {
+				if ($t_item->hasField('is_deaccessioned') && $t_item->get('is_deaccessioned') && ($t_item->get('deaccession_date', array('getDirectDate' => true)) <= caDateToHistoricTimestamp(TimeExpressionParser::nowExpression()))) {
 					// If currently deaccessioned then display deaccession message
 					$vs_buf .= "<br/><div class='inspectorDeaccessioned'>"._t('Deaccessioned %1', $t_item->get('deaccession_date'))."</div>\n";
 					if ($vs_deaccession_notes = $t_item->get('deaccession_notes')) { TooltipManager::add(".inspectorDeaccessioned", $vs_deaccession_notes); }

--- a/app/helpers/utilityHelpers.php
+++ b/app/helpers/utilityHelpers.php
@@ -2932,7 +2932,7 @@ function caFileIsIncludable($ps_file) {
 	 */
 	function caIsCurrentDate($ps_date_expression) {
 		if ($va_date = caDateToHistoricTimestamps($ps_date_expression)) {
-			$va_now = caDateToHistoricTimestamps(_t('now'));
+			$va_now = caDateToHistoricTimestamps(TimeExpressionParser::nowExpression());
 			if (
 				(($va_date['start'] <= $va_now['start'])
 				&&
@@ -2953,7 +2953,7 @@ function caFileIsIncludable($ps_file) {
 	 */
 	function caDateEndsInFuture($ps_date_expression) {
 		if ($va_date = caDateToHistoricTimestamps($ps_date_expression)) {
-			$va_now = caDateToHistoricTimestamps(_t('now'));
+			$va_now = caDateToHistoricTimestamps(TimeExpressionParser::nowExpression());
 			if (
 				($va_date['end'] >= $va_now['end'])
 			) {

--- a/app/lib/BaseEditorController.php
+++ b/app/lib/BaseEditorController.php
@@ -249,7 +249,7 @@ class BaseEditorController extends ActionController {
 		if($vn_subject_id && $vs_rel_table && $vn_rel_type_id && $vn_rel_id) {
 			if(Datamodel::tableExists($vs_rel_table)) {
 				Debug::msg("[Save()] Relating new record using parameters from request: $vs_rel_table / $vn_rel_type_id / $vn_rel_id");
-				$t_subject->addRelationship($vs_rel_table, $vn_rel_id, $vn_rel_type_id, _t('now'));
+				$t_subject->addRelationship($vs_rel_table, $vn_rel_id, $vn_rel_type_id, TimeExpressionParser::nowExpression());
 			}
 			$this->notification->addNotification(_t("Added relationship"), __NOTIFICATION_TYPE_INFO__);
 			$this->render('screen_html.php');
@@ -2813,7 +2813,7 @@ class BaseEditorController extends ActionController {
 								foreach($interstitial_elements as $e) {
 									switch($e) {
 										case 'effective_date':
-											$effective_date = _t('today');
+											$effective_date = TimeExpressionParser::todayExpression();
 											break;
 									}
 								}

--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -10619,9 +10619,9 @@ $pa_options["display_form_field_tips"] = true;
 		
 		if (!is_null($pn_moderator)) {
 			$t_ixt->set('moderated_by_user_id', $pn_moderator);
-			$t_ixt->set('moderated_on', _t('now'));
+			$t_ixt->set('moderated_on', TimeExpressionParser::nowExpression());
 		}elseif(caGetOption('forceModerated', $pa_options, false) || $this->_CONFIG->get("dont_moderate_comments")){
-			$t_ixt->set('moderated_on', _t('now'));
+			$t_ixt->set('moderated_on', TimeExpressionParser::nowExpression());
 		}
 		
 		$t_ixt->insert();
@@ -12495,7 +12495,7 @@ $pa_options["display_form_field_tips"] = true;
 
 		$t_notification->set('notification_type', $pn_type);
 		$t_notification->set('message', $ps_message);
-		$t_notification->set('datetime', caGetOption('datetime', $pa_options, _t('now')));
+		$t_notification->set('datetime', caGetOption('datetime', $pa_options, TimeExpressionParser::nowExpression()));
 		$t_notification->set('is_system', $pb_system ? 1 : 0);
 		$t_notification->set('notification_key', caGetOption('key', $pa_options, null));
 		
@@ -12531,7 +12531,7 @@ $pa_options["display_form_field_tips"] = true;
 			// Send email immediately when queue is not enabled
 			if ((!defined("__CA_QUEUE_ENABLED__") || !__CA_QUEUE_ENABLED__) && (bool)$vb_send_email && $this->hasField('email') && ($vs_to_email = $this->get('email'))) {
 				if (caSendMessageUsingView(null, $vs_to_email, $vs_sender_email, $this->getAppConfig()->get('notification_email_subject'), "notification.tpl", ['notification' => $ps_message, 'sent_on' => time()],null, null, ['source' => 'Notification'])) {
-					$t_subject->set('delivery_email_sent_on', _t('now'));
+					$t_subject->set('delivery_email_sent_on', TimeExpressionParser::nowExpression());
 					$t_subject->update();
 				} // caSendMessageUsingView logs failures
 			}
@@ -12565,7 +12565,7 @@ $pa_options["display_form_field_tips"] = true;
 				// Send email immediately when queue is not enabled
 				if ((!defined("__CA_QUEUE_ENABLED__") || !__CA_QUEUE_ENABLED__) && (bool)$vb_send_email && $t_instance->hasField('email') && ($t_instance->load($va_subject['row_id'])) &&  ($vs_to_email = $t_instance->get('email'))) {
 					if (caSendMessageUsingView(null, $vs_to_email, $vs_sender_email, $this->getAppConfig()->get('notification_email_subject'), "notification.tpl", ['notification' => $ps_message, 'datetime' => time(), 'datetime_display' => caGetLocalizedDate()], null, null, ['source' => 'Notification'])) {
-						$t_subject->set('delivery_email_sent_on', _t('now'));
+						$t_subject->set('delivery_email_sent_on', TimeExpressionParser::nowExpression());
 						$t_subject->update();
 					} // caSendMessageUsingView logs failures
 				}

--- a/app/lib/HistoryTrackingCurrentValueTrait.php
+++ b/app/lib/HistoryTrackingCurrentValueTrait.php
@@ -2428,7 +2428,7 @@
 								$field_class = '';
 								break;
 						}
-						$buf .= "<td><div class='formLabel'>{$label}<br/>".$t_rel->htmlFormElement($element_code, '', ['name' => "{$id_prefix}_{$rel_table}_{$type_idno}_{$element_code}".($no_template ? '' : '{n}'), 'id' => "{$id_prefix}_{$rel_table}_{$type_idno}_{$element_code}".($no_template ? '' : '{n}'), 'value' => _t('now'), 'classname' => $field_class])."</td>";
+						$buf .= "<td><div class='formLabel'>{$label}<br/>".$t_rel->htmlFormElement($element_code, '', ['name' => "{$id_prefix}_{$rel_table}_{$type_idno}_{$element_code}".($no_template ? '' : '{n}'), 'id' => "{$id_prefix}_{$rel_table}_{$type_idno}_{$element_code}".($no_template ? '' : '{n}'), 'value' => TimeExpressionParser::nowExpression(), 'classname' => $field_class])."</td>";
 					} else {
 						$buf .= "<td class='formLabel'>{$label}<br/>".$t_rel->getAttributeHTMLFormBundle($request, null, $element_code, $placement_code, $settings, ['elementsOnly' => true])."</td>";
 					}	

--- a/app/lib/MediaUploadManager.php
+++ b/app/lib/MediaUploadManager.php
@@ -98,7 +98,7 @@ class MediaUploadManager {
     static public function completeSession($key, $user_id=null){
 		$s = MediaUploadManager::findSession($key, $user_id);
 		
-		$s->set('completed_on', _t('now'));
+		$s->set('completed_on', TimeExpressionParser::nowExpression());
 		$s->set('status', 'COMPLETED');
 		$s->update();
 		if ($s->numErrors() > 0) {
@@ -112,7 +112,7 @@ class MediaUploadManager {
      */
     static public function cancelSession($key, $user_id=null){
 		$s = MediaUploadManager::findSession($key, $user_id);
-		$s->set('completed_on', _t('now'));
+		$s->set('completed_on', TimeExpressionParser::nowExpression());
 		$s->set('cancelled', 1);
 		$s->set('status', 'CANCELLED');
 		$s->update();
@@ -325,13 +325,13 @@ class MediaUploadManager {
 
 			// ...
 			if ($session = MediaUploadManager::findSession($key, $user_id)) {
-				$session->set('last_activity_on', _t('now'));
+				$session->set('last_activity_on', TimeExpressionParser::nowExpression());
 				
 				$fp = self::_partialToFinalPath($fileMeta['file_path']);
 				
 				$session->setFile($fp, [
 					'bytes_received' => $fileMeta['offset'], 'total_bytes' => $fileMeta['size'],
-					'completed_on' => ($fileMeta['offset'] == $fileMeta['size']) ? _t('now') : null, 'last_activity_on' => _t('now'), 
+					'completed_on' => ($fileMeta['offset'] == $fileMeta['size']) ? TimeExpressionParser::nowExpression() : null, 'last_activity_on' => TimeExpressionParser::nowExpression(), 
 					'error_code' => null
 				]);
 				$session->updateStats();
@@ -348,11 +348,11 @@ class MediaUploadManager {
 				
 			// ...
 			if ($session = MediaUploadManager::findSession($key, $user_id)) {
-				$session->set('last_activity_on', _t('now'));
+				$session->set('last_activity_on', TimeExpressionParser::nowExpression());
 				
 				$session->setFile($fp, [
 					'bytes_received' => $fileMeta['offset'], 'total_bytes' => $fileMeta['size'],
-					'completed_on' => _t('now'), 'last_activity_on' => _t('now'), 
+					'completed_on' => TimeExpressionParser::nowExpression(), 'last_activity_on' => TimeExpressionParser::nowExpression(), 
 					'error_code' => null
 				]);
 				

--- a/app/lib/Parsers/TimeExpressionParser.php
+++ b/app/lib/Parsers/TimeExpressionParser.php
@@ -4188,5 +4188,54 @@ class TimeExpressionParser {
 		}
 		return ($dates['start']['year'] - ($dates['start']['year'] % 10)).$decade_indicator;
  	}
+ 	# -------------------------------------------------------------------
+ 	/** 
+ 	 * Return a setting value for a locale.If no locale is 
+ 	 * specified the current UI locale is used, or if that is unavailable the system default
+ 	 * locale is used.
+ 	 *
+ 	 * @param string $setting
+ 	 * @param string $locale
+ 	 *
+ 	 * @return string|array The setting value, or null is the setting is not defined
+ 	 */
+ 	static public function localeSetting(string $setting, ?string $locale=null) {
+ 		global $g_ui_locale;
+ 		
+ 		if(!$locale) { $locale = $g_ui_locale; }
+ 		if(!$locale && defined('__CA_DEFAULT_LOCALE__')) { $locale = __CA_DEFAULT_LOCALE__; }
+ 		
+ 		$lang = Configuration::load(__CA_LIB_DIR__.'/Parsers/TimeExpressionParser/'.$locale.'.lang');
+ 		
+ 		return $lang->get($setting);
+ 	}
+ 	# -------------------------------------------------------------------
+ 	/** 
+ 	 * Return primary (first configured) phrase for "now" for a locale. If no locale is 
+ 	 * specified the current UI locale is used, or if that is unavailable the system default
+ 	 * locale is used.
+ 	 *
+ 	 * @param string $locale 
+ 	 *
+ 	 * @return string
+ 	 */
+ 	static public function nowExpression(?string $locale=null) : string {
+ 		$nows = self::localeSetting('nowDate', $locale);
+ 		return (is_array($nows) && sizeof($nows)) ? array_shift($nows) : null;
+ 	}
+ 	# -------------------------------------------------------------------
+ 	/** 
+ 	 * Return primary (first configured) phrase for "today" for a locale. If no locale is 
+ 	 * specified the current UI locale is used, or if that is unavailable the system default
+ 	 * locale is used.
+ 	 *
+ 	 * @param string $locale 
+ 	 *
+ 	 * @return string
+ 	 */
+ 	static public function todayExpression(?string $locale=null) : string {
+ 		$todays = self::localeSetting('todayDate', $locale);
+ 		return (is_array($todays) && sizeof($todays)) ? array_shift($todays) : null;
+ 	}
  	# ------------------------------------------------------------------- 	
 }

--- a/app/models/ca_data_import_events.php
+++ b/app/models/ca_data_import_events.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2008-2010 Whirl-i-Gig
+ * Copyright 2008-2022 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -281,7 +281,7 @@ class ca_data_import_events extends BaseModel {
 		
 		$this->opo_data_import_item->setMode(ACCESS_WRITE);
 		$this->opo_data_import_item->set('event_id', $vn_event_id);
-		$this->opo_data_import_item->set('completed_on', _t("now"));
+		$this->opo_data_import_item->set('completed_on', TimeExpressionParser::nowExpression());
 		$this->opo_data_import_item->set('elapsed_time', (microtime(true) - $this->opn_start_time));
 	
 		$this->opo_data_import_item->set('success', (int)$pn_success);

--- a/app/models/ca_item_comments.php
+++ b/app/models/ca_item_comments.php
@@ -346,7 +346,7 @@ class ca_item_comments extends BaseModel {
 		if (!$this->getPrimaryKey()) { return null; }
 		$this->setMode(ACCESS_WRITE);
 		$this->set('moderated_by_user_id', $user_id);
-		$this->set('moderated_on', _t('now'));
+		$this->set('moderated_on', TimeExpressionParser::nowExpression());
 		return $this->update();
 	}
 	# ------------------------------------------------------

--- a/app/models/ca_media_upload_sessions.php
+++ b/app/models/ca_media_upload_sessions.php
@@ -635,7 +635,7 @@ class ca_media_upload_sessions extends BaseModel {
 			
 			// TODO: write ids of records created into session for playback when session is viewed
 			
-			$session->set('completed_on', _t('now'));
+			$session->set('completed_on', TimeExpressionParser::nowExpression());
 			$session->set('status', 'PROCESSED');
 			$session->update();
 			
@@ -724,7 +724,7 @@ class ca_media_upload_sessions extends BaseModel {
 			]
 		));
 		
-		$session->set('completed_on', _t('now'));
+		$session->set('completed_on', TimeExpressionParser::nowExpression());
 		$session->set('status', 'ERROR');
 		return $session->update();
 	}

--- a/app/models/ca_movements_x_storage_locations.php
+++ b/app/models/ca_movements_x_storage_locations.php
@@ -256,7 +256,7 @@ class ca_movements_x_storage_locations extends BaseRelationshipModel {
 				$date = $t_movement->get("ca_movements.{$movement_storage_element}");
 			}
 		}
-		return ($date) ? $date : _t('now');
+		return ($date) ? $date : TimeExpressionParser::nowExpression();
 	}
 	# ------------------------------------------------------
 	/**

--- a/app/models/ca_notification_subjects.php
+++ b/app/models/ca_notification_subjects.php
@@ -216,7 +216,7 @@ class ca_notification_subjects extends BaseModel {
 	 */
 	public function insert($pa_options=null) {
 		if ($this->get('was_read')) { 
-			$this->set('read_on', _t('now'));
+			$this->set('read_on', TimeExpressionParser::nowExpression());
 		}
 		return parent::insert($pa_options);
 	}
@@ -226,7 +226,7 @@ class ca_notification_subjects extends BaseModel {
 	 */
 	public function update($pa_options=null) {
 		if ($this->changed('was_read') && $this->get('was_read')) { 
-			$this->set('read_on', _t('now'));
+			$this->set('read_on', TimeExpressionParser::nowExpression());
 		}
 		return parent::update($pa_options);
 	}

--- a/app/models/ca_object_checkouts.php
+++ b/app/models/ca_object_checkouts.php
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------
  *
  * Software by Whirl-i-Gig (http://www.whirl-i-gig.com)
- * Copyright 2014-2019 Whirl-i-Gig
+ * Copyright 2014-2022 Whirl-i-Gig
  *
  * For more information visit http://www.CollectiveAccess.org
  *
@@ -397,19 +397,17 @@ class ca_object_checkouts extends BundlableLabelableBaseModelWithAttributes {
 			$ps_due_date = isset($va_checkout_config['default_checkout_date']) ? $va_checkout_config['default_checkout_date'] : null;
 		}
 		
-		$this->setMode(ACCESS_WRITE);
 		$this->set(array(
 			'group_uuid' => $vs_uuid,
 			'object_id' => $pn_object_id,
 			'user_id' => $pn_user_id,
 			'checkout_notes' => $ps_note,
-			'checkout_date' => _t('today'),
+			'checkout_date' => TimeExpressionParser::nowExpression(),
 			'due_date' => $ps_due_date
 		));	
 		
 		// Do we need to set values?
 		if (is_array($va_checkout_config['set_values']) && sizeof($va_checkout_config['set_values'])) {
-			$t_object->setMode(ACCESS_WRITE);
 			foreach($va_checkout_config['set_values'] as $vs_attr => $va_attr_values_by_event) {
 				if (!is_array($va_attr_values_by_event['checkout'])) {
 					if ($t_object->hasField($vs_attr)) {
@@ -462,15 +460,13 @@ class ca_object_checkouts extends BundlableLabelableBaseModelWithAttributes {
 			throw new Exception(_t('Item is not out'));
 		}
 		
-		$this->setMode(ACCESS_WRITE);
 		$this->set(array(
-			'return_date' => _t('now'),
+			'return_date' => TimeExpressionParser::nowExpression(),
 			'return_notes' => $ps_note
 		));	
 		
 		// Do we need to set values?
 		if (is_array($va_checkout_config['set_values']) && sizeof($va_checkout_config['set_values'])) {
-			$t_object->setMode(ACCESS_WRITE);
 			foreach($va_checkout_config['set_values'] as $vs_attr => $va_attr_values_by_event) {
 				if (!is_array($va_attr_values_by_event['checkin'])) {
 					if ($t_object->hasField($vs_attr)) {
@@ -537,7 +533,6 @@ class ca_object_checkouts extends BundlableLabelableBaseModelWithAttributes {
 			throw new ApplicationException(_t("Configuration for type %1 does not exist", $type_code));
 		}
 		
-		$this->setMode(ACCESS_WRITE);
 		$this->set(array(
 			'group_uuid' => $vs_uuid,
 			'object_id' => $pn_object_id,
@@ -547,7 +542,6 @@ class ca_object_checkouts extends BundlableLabelableBaseModelWithAttributes {
 		
 		// Do we need to set values?
 		if (is_array($va_checkout_config['set_values']) && sizeof($va_checkout_config['set_values'])) {
-			$t_object->setMode(ACCESS_WRITE);
 			foreach($va_checkout_config['set_values'] as $vs_attr => $va_attr_values_by_event) {
 				if (!is_array($va_attr_values_by_event['reserve'])) {
 					if ($t_object->hasField($vs_attr)) {
@@ -1430,7 +1424,7 @@ class ca_object_checkouts extends BundlableLabelableBaseModelWithAttributes {
 	 */
 	static public function getDashboardStatistics($ps_datetime=null, $pa_options=null) {
 		if (!($o_db = caGetOption('db', $pa_options, null))) { $o_db = new Db(); }
-		if (!$ps_datetime) { $ps_datetime = _t('today'); }
+		if (!$ps_datetime) { $ps_datetime = TimeExpressionParser::todayExpression(); }
 		
 		$va_stats = array(
 			'numOverdueCheckouts' => ca_object_checkouts::numOverdueCheckouts($ps_datetime),			//	Number of individual copies checked-out and overdue

--- a/app/models/ca_object_representations.php
+++ b/app/models/ca_object_representations.php
@@ -2431,7 +2431,7 @@ class ca_object_representations extends BundlableLabelableBaseModelWithAttribute
 		if (caGetOption('uncomplete', $options, false)) {
 			$transcript->set('completed_on', null);
 		} elseif ($complete) {
-			$transcript->set('completed_on', _t('now'));	
+			$transcript->set('completed_on', TimeExpressionParser::nowExpression());	
 		}
 		if ($user_id) {
 			$transcript->set('user_id', $user_id);

--- a/app/models/ca_objects_x_storage_locations.php
+++ b/app/models/ca_objects_x_storage_locations.php
@@ -222,7 +222,7 @@ class ca_objects_x_storage_locations extends ObjectRelationshipBaseModel {
 	 */
 	public function insert($options=null) {
 		if (!caGetOption('dontAutomaticallySetEffectiveDate', $options, false) && !$this->get('effective_date', array('getDirectDate' => true))) {  
-			$this->set('effective_date', _t('now')); 
+			$this->set('effective_date', TimeExpressionParser::nowExpression()); 
 		}
 		
 		return parent::insert($options);
@@ -233,7 +233,7 @@ class ca_objects_x_storage_locations extends ObjectRelationshipBaseModel {
 	 */
 	public function update($options=null) {
 		if (!caGetOption('dontAutomaticallySetEffectiveDate', $options, false) && !$this->get('effective_date', array('getDirectDate' => true))) { 
-			$this->set('effective_date', _t('now')); 
+			$this->set('effective_date', TimeExpressionParser::nowExpression()); 
 		}
 		
 		return parent::update($options);

--- a/app/plugins/libraryServices/libraryServicesPlugin.php
+++ b/app/plugins/libraryServices/libraryServicesPlugin.php
@@ -91,7 +91,7 @@ class libraryServicesPlugin extends BaseApplicationPlugin {
 									// mark record
 									foreach($va_items_for_user as $va_item) {
 										if ($t_checkout->load($va_item['checkout_id'])) {
-											$t_checkout->set('last_sent_coming_due_email', _t('now'));	
+											$t_checkout->set('last_sent_coming_due_email', TimeExpressionParser::nowExpression());	
 											$t_checkout->update();
 											if ($t_checkout->numErrors()) {
 												$t_log->log(array('CODE' => 'ERR', 'MESSAGE' => _t('Could not mark checkout coming due message sent time because update failed: %1', join("; ", $t_checkout->getErrors())), 'SOURCE' => 'libraryServicesPlugin->hookPeriodicTask'));	
@@ -128,7 +128,7 @@ class libraryServicesPlugin extends BaseApplicationPlugin {
 									// mark record
 									foreach($va_items_for_user as $va_item) {
 										if ($t_checkout->load($va_item['checkout_id'])) {
-											$t_checkout->set('last_sent_overdue_email', _t('now'));	
+											$t_checkout->set('last_sent_overdue_email', TimeExpressionParser::nowExpression());	
 											$t_checkout->update();
 											if ($t_checkout->numErrors()) {
 												$t_log->log(array('CODE' => 'ERR', 'MESSAGE' => _t('Could not mark checkout overdue message sent time because update failed: %1', join("; ", $t_checkout->getErrors())), 'SOURCE' => 'libraryServicesPlugin->hookPeriodicTask'));	
@@ -165,7 +165,7 @@ class libraryServicesPlugin extends BaseApplicationPlugin {
 									// mark record
 									foreach($va_items_for_user as $va_item) {
 										if ($t_checkout->load($va_item['checkout_id'])) {
-											$t_checkout->set('last_reservation_available_email', _t('now'));	
+											$t_checkout->set('last_reservation_available_email', TimeExpressionParser::nowExpression());	
 											$t_checkout->update();
 											if ($t_checkout->numErrors()) {
 												$t_log->log(array('CODE' => 'ERR', 'MESSAGE' => _t('Could not mark reserved available message sent time because update failed: %1', join("; ", $t_checkout->getErrors())), 'SOURCE' => 'libraryServicesPlugin->hookPeriodicTask'));	

--- a/app/plugins/notifications/notificationsPlugin.php
+++ b/app/plugins/notifications/notificationsPlugin.php
@@ -81,7 +81,7 @@
 						foreach($va_notification_subject_ids as $vn_subject_id) {
 							if ($t_subject->load($vn_subject_id)) {
 								$t_subject->setMode(ACCESS_WRITE);
-								$t_subject->set('delivery_email_sent_on', _t('now'));
+								$t_subject->set('delivery_email_sent_on', TimeExpressionParser::nowExpression());
 								if (!$t_subject->update()) {
 									$t_log->log(array('CODE' => 'ERR', 'MESSAGE' => _t('Could not set notification subject %1 as read: %2', $vn_subject_id, join('; ', $t_subject->getErrors())), 'SOURCE' => 'notificationsPlugin->hookPeriodicTask'));
 									continue;

--- a/app/refineries/dateJoiner/dateJoinerRefinery.php
+++ b/app/refineries/dateJoiner/dateJoinerRefinery.php
@@ -85,7 +85,7 @@
 					
 					$va_date = array();
 					if ($vs_date_start = BaseRefinery::parsePlaceholder($vs_date_start, $pa_source_data, $pa_item, $vn_c, array('reader' => caGetOption('reader', $pa_options, null), 'returnAsString' => true))) { 
-						if ($pa_item['settings']['dateJoiner_ignorePresentDayStartDates'] && (caDateToUnixTimestamp($vs_date_start) === caDateToUnixTimestamp(_t('today')))) {
+						if ($pa_item['settings']['dateJoiner_ignorePresentDayStartDates'] && (caDateToUnixTimestamp($vs_date_start) === caDateToUnixTimestamp(TimeExpressionParser::todayExpression()))) {
 						    $vs_date_start = '';
 						}
 						if (
@@ -101,7 +101,7 @@
 						}
 					}
 					if ($vs_date_end = BaseRefinery::parsePlaceholder($vs_date_end, $pa_source_data, $pa_item, $vn_c, array('reader' => caGetOption('reader', $pa_options, null), 'returnAsString' => true))) { 
-						if ($pa_item['settings']['dateJoiner_ignorePresentDayEndDates'] && (caDateToUnixTimestamp($vs_date_end) === caDateToUnixTimestamp(_t('today')))) {
+						if ($pa_item['settings']['dateJoiner_ignorePresentDayEndDates'] && (caDateToUnixTimestamp($vs_date_end) === caDateToUnixTimestamp(TimeExpressionParser::todayExpression()))) {
 						    $vs_date_end = ($vs_date_start) ? _t('present') : "";
 						}
 						


### PR DESCRIPTION
…values pulled directly from the date/time parser, to ensure timestamps are correctly applied across locales.